### PR TITLE
Fix filtering and argument handling

### DIFF
--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -32,7 +32,7 @@ namespace ComicRentalSystem_14Days.Forms
 
             _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
             _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
-            _reloadService = reloadService ?? throw new ArgumentException(nameof(reloadService));
+            _reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
 
             if (_comicService != null)
             {

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -932,11 +932,11 @@ namespace ComicRentalSystem_14Days
             if (this.cmbAdminComicFilterStatus != null && this.cmbAdminComicFilterStatus.SelectedItem != null)
             {
                 string? selectedStatus = this.cmbAdminComicFilterStatus.SelectedItem.ToString();
-                if (selectedStatus == "Rented")
+                if (selectedStatus == "已租借")
                 {
                     viewToShow = viewToShow.Where(vm => vm.Status == "被借閱");
                 }
-                else if (selectedStatus == "Available")
+                else if (selectedStatus == "可租借")
                 {
                     viewToShow = viewToShow.Where(vm => vm.Status == "在館中");
                 }


### PR DESCRIPTION
## Summary
- correct Admin comic status filtering to respect Chinese text values
- throw `ArgumentNullException` for missing reload service

## Testing
- `dotnet build ComicRentalSystem_14Days.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8dce0f5c83278300d094dda0703f