### PR TITLE
Fix comic save freeze

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
@@ -171,9 +171,9 @@ namespace ComicRentalSystem_14Days.Forms
             }
         }
 
-        private void btnSave_Click(object sender, EventArgs e)
+        private async void btnSave_Click(object sender, EventArgs e)
         {
-            btnSave_ClickAsync(sender, e).GetAwaiter().GetResult();
+            await btnSave_ClickAsync(sender, e);
         }
 
         private void btnCancel_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- fix deadlock when saving a comic by using async event handler

## Testing
- `dotnet build ComicRentalSystem_14Days.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fae4e57848327b63e79c62058df39