### PR TITLE
Fix CS1524: Add missing catch block in ComicService.AddComic

### DIFF
--- a/ComicRentalSystem_14Days/Services/ComicService.cs
+++ b/ComicRentalSystem_14Days/Services/ComicService.cs
@@ -95,14 +95,14 @@ namespace ComicRentalSystem_14Days.Services
                 {
                     _logger.LogWarning($"書名='{comic.Title}' 且作者='{comic.Author}' 相同的漫畫已存在。繼續新增。");
                 }
+                _context.SaveChanges(); // Moved inside try
+                OnComicsChanged();    // Moved inside try
             } // Closes the try block
-            // Potentially add a catch block here if needed, or save changes if no catch.
-            // For now, just closing the try and method.
-            // Consider if _context.SaveChanges() was intended here. Based on AddComicAsync, it seems so.
-            // However, the original issue is only about the missing brace.
-            // Let's assume SaveChanges() should be called before closing the method, similar to UpdateComic and DeleteComic.
-            _context.SaveChanges(); // Added SaveChanges based on other methods' patterns
-            OnComicsChanged(); // Also common pattern after DB modification
+            catch (DbUpdateException ex)
+            {
+                _logger.LogError($"Error adding comic '{comic.Title}' to database.", ex);
+                throw new InvalidOperationException($"Could not add comic. Possible constraint violation or other database error.", ex);
+            }
         } // Closes the AddComic method
 
         public async Task AddComicAsync(Comic comic)


### PR DESCRIPTION
The AddComic method in ComicService.cs was missing a catch or finally block for a try statement, causing a CS1524 compilation error.

This commit adds the required catch (DbUpdateException ex) block to handle potential database update errors during comic creation. The _context.SaveChanges() and OnComicsChanged() calls were also moved inside the try block to ensure they are executed only if the preceding operations are successful.