### PR TITLE
Fix: LogManagementForm opens twice when accessed via navigation button

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -1106,8 +1106,6 @@ namespace ComicRentalSystem_14Days
             {
                 SelectNavButton(cb);
                 _logger?.Log("Logs navigation button clicked.");
-                using var f = new LogManagementForm((FileLogger)_logger!);
-                f.ShowDialog(this);
             }
         }
 


### PR DESCRIPTION
The LogManagementForm was being instantiated and shown twice when the administrator clicked the 'Log Management' navigation button (btnNavLogs).

This occurred because:
1. The `btnNavLogs_Click` event handler called `SelectNavButton()`.
2. `SelectNavButton()` itself contained logic to open the `LogManagementForm` when `btnNavLogs` was the selected button (by calling `日誌管理ToolStripMenuItem_Click`).
3. After the `SelectNavButton()` call returned, `btnNavLogs_Click` then proceeded to instantiate and show the `LogManagementForm` again.

This commit removes the redundant instantiation of `LogManagementForm` from the `btnNavLogs_Click` event handler. The responsibility for showing the form is now solely within the `SelectNavButton` method's logic path (via `日誌管理ToolStripMenuItem_Click`).

This ensures that the form opens only once as intended.