### PR TITLE
Fix: Resolve DbContext concurrency exceptions

### DIFF
--- a/ComicRentalSystem_14Days/Program.cs
+++ b/ComicRentalSystem_14Days/Program.cs
@@ -17,7 +17,6 @@ namespace ComicRentalSystem_14Days
     {
         public static ILogger? AppLogger { get; private set; }
         public static FileHelper? AppFileHelper { get; private set; } // Retained for now, in case FileLogger or other parts might use it.
-        public static ComicRentalDbContext? AppDbContext { get; private set; } // Added DbContext
         public static IComicService? AppComicService { get; private set; }
         public static MemberService? AppMemberService { get; private set; }
         public static IReloadService? AppReloadService { get; private set; }
@@ -154,26 +153,25 @@ namespace ComicRentalSystem_14Days
             AppLogger.Log("Database context disposed after migration check/process.");
             // --- END DATA MIGRATION TO SQLITE ---
 
-            AppLogger.Log("Initializing main application DbContext...");
-            AppDbContext = new ComicRentalDbContext();
-            AppLogger.Log("Main application DbContext initialized.");
+            // AppDbContext is no longer initialized here. Services will manage their own.
 
-            if (AppDbContext != null && AppLogger != null)
+            if (AppLogger != null) // AppDbContext check removed
             {
-                AppComicService = new ComicService(AppDbContext, AppLogger);
-                AppLogger.Log("ComicService initialized with DbContext.");
+                AppComicService = new ComicService(AppLogger); // AppDbContext removed
+                AppLogger.Log("ComicService initialized.");
 
-                AppMemberService = new MemberService(AppDbContext, AppLogger, AppComicService);
-                AppLogger.Log("MemberService initialized with DbContext.");
+                AppMemberService = new MemberService(AppLogger, AppComicService); // AppDbContext removed
+                AppLogger.Log("MemberService initialized.");
 
-                AppAuthService = new AuthenticationService(AppDbContext, AppLogger);
-                AppLogger.Log("AuthenticationService initialized with DbContext.");
+                AppAuthService = new AuthenticationService(AppLogger); // AppDbContext removed
+                AppLogger.Log("AuthenticationService initialized.");
 
-                AppAuthService.EnsureAdminUserExists("admin", "admin123");
+                AppAuthService.EnsureAdminUserExists("admin", "admin123"); // This call remains
             }
             else
             {
-                AppLogger?.LogError("Critical error: AppDbContext or AppLogger is null. Cannot initialize core services.");
+                // Simplified error logging as AppDbContext is no longer a factor here for service init
+                AppLogger?.LogError("Critical error: AppLogger is null. Cannot initialize core services.");
             }
 
             Application.ThreadException += new System.Threading.ThreadExceptionEventHandler(Application_ThreadException);


### PR DESCRIPTION
System.InvalidOperationException: A second operation was started on this context instance before a previous operation completed.

This commit addresses the concurrency issue by changing the DbContext lifecycle management. Previously, a single DbContext instance (AppDbContext) was shared across various services (ComicService, MemberService, AuthenticationService). This led to errors when multiple asynchronous operations or operations on different threads attempted to use the DbContext concurrently.

The fix involves the following changes:

1.  **Program.cs**: Removed the static `AppDbContext`. Services are now instantiated without a shared DbContext instance.
2.  **Service Layer (ComicService.cs, MemberService.cs, AuthenticationService.cs)**:
    *   Constructors no longer accept a DbContext.
    *   Each method performing database operations now creates a new `ComicRentalDbContext` instance within a `using` block. This ensures that each operation has its own isolated context, preventing concurrent access violations.
3.  **MainForm.cs**: No direct changes were needed as it correctly consumes the services. The underlying changes in the services resolve the exceptions that originated from calls within MainForm (e.g., LoadAllComicsStatusForAdminAsync).

This change ensures that DbContext operations are properly scoped, making your application more robust and preventing the previously observed InvalidOperationExceptions.