### PR TITLE
Here's how I fixed the compiler errors in `ComicService.cs`:

### DIFF
--- a/ComicRentalSystem_14Days/Services/ComicService.cs
+++ b/ComicRentalSystem_14Days/Services/ComicService.cs
@@ -143,13 +143,6 @@ namespace ComicRentalSystem_14Days.Services
         }
 
         public async Task AddComicAsync(Comic comic)
-            {
-                _logger.LogError($"Error adding comic '{comic.Title}' to database (obsolete).", ex);
-                throw new InvalidOperationException($"Could not add comic (obsolete). Possible constraint violation or other database error.", ex);
-            }
-        }
-
-        public async Task AddComicAsync(Comic comic)
         {
             if (comic == null)
             {


### PR DESCRIPTION
- I removed a faulty and duplicated `AddComicAsync` method that was causing multiple compilation errors (CS0103, CS1998, CS1519, CS0111).
- This change should also resolve cascading parse errors (CS1513, CS0106, CS8321) and the interface implementation error CS0535 for `SearchComics` by allowing the compiler to correctly parse the class structure.
- I confirmed that the `SearchComics` method signature matches the `IComicService` interface.
- No changes were needed for class closing braces as they were found to be correct.