### PR TITLE
Fix missing list fields and update null checks

### DIFF
--- a/ComicRentalSystem_14Days/Forms/LogManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/LogManagementForm.cs
@@ -12,9 +12,9 @@ namespace ComicRentalSystem_14Days.Forms
 
         public LogManagementForm(FileLogger logger) : base(logger)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             InitializeComponent();
-            _logger = logger;
-            numericRetentionDays.Value = _logger != null ? _logger.GetType().GetField("_retentionDays", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_logger) as int? ?? 90 : 90;
+            numericRetentionDays.Value = _logger.GetType().GetField("_retentionDays", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_logger) as int? ?? 90;
             LoadLogFiles();
         }
 

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -616,7 +616,7 @@ namespace ComicRentalSystem_14Days
 
             try
             {
-                Member? currentMember = _memberService!.GetMemberByUsername(_currentUser.Username);
+                Member? currentMember = _memberService!.GetMemberByUsername(_currentUser!.Username);
                 if (currentMember == null)
                 {
                     _logger?.LogWarning($"載入我的租借漫畫失敗：找不到使用者名稱 '{_currentUser?.Username ?? "未知使用者"}' 的會員資料。未載入任何租借記錄。");

--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -43,7 +43,7 @@ namespace ComicRentalSystem_14Days.Services
         public User? GetUserByUsername(string username)
         {
             _logger.Log($"正在嘗試透過使用者名稱擷取使用者: {username}");
-            User? user = _users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            User? user = _context.Users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
           
             if (user == null)
             {
@@ -68,7 +68,7 @@ namespace ComicRentalSystem_14Days.Services
         public bool Register(string username, string password, UserRole role)
         {
             _logger.Log($"使用者名稱註冊嘗試: {username}，角色: {role}");
-            if (_users.Any(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant()))
+            if (_context.Users.Any(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant()))
             {
                 _logger.LogWarning($"Registration failed for {username}: Username already exists.");
                 return false;
@@ -99,7 +99,7 @@ namespace ComicRentalSystem_14Days.Services
         public User? Login(string username, string password)
         {
             _logger.Log($"使用者名稱登入嘗試: {username}");
-            User? user = _users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            User? user = _context.Users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
 
             if (user == null)
             {
@@ -167,7 +167,7 @@ namespace ComicRentalSystem_14Days.Services
         public bool DeleteUser(string username)
         {
             _logger.Log($"正在嘗試刪除使用者: {username}"); 
-            User? userToDelete = _users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            User? userToDelete = _context.Users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
 
             if (userToDelete != null)
             {

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -175,7 +175,7 @@ namespace ComicRentalSystem_14Days.Services
                 return null;
             }
             _logger.Log($"已為姓名: '{name}' 呼叫 GetMemberByName。");
-            Member? member = _members.FirstOrDefault(m => m.Name.ToUpperInvariant() == name.ToUpperInvariant());
+            Member? member = _context.Members.FirstOrDefault(m => m.Name.ToUpperInvariant() == name.ToUpperInvariant());
             if (member == null)
             {
                 _logger.Log($"Member with name: '{name}' not found.");
@@ -214,20 +214,10 @@ namespace ComicRentalSystem_14Days.Services
                 _logger.LogWarning("GetMemberByUsername called with empty or whitespace username.");
                 return null;
             }
-            var allMembers = GetAllMembers();
+            _logger.Log($"GetMemberByUsername called for username: '{username}'.");
+            Member? member = _context.Members.FirstOrDefault(m => m.Username != null && m.Username.ToUpperInvariant() == username.ToUpperInvariant());
 
-            if (allMembers == null || !allMembers.Any())
-            {
-                _logger.LogWarning("GetMemberByUsername: 無可用會員進行搜尋。");
-                return null;
-            }
-
-            string userUpper = username.ToUpperInvariant();
-            Member? foundMember = allMembers.FirstOrDefault(m =>
-                m.Username != null && m.Username.ToUpperInvariant() == userUpper
-            );
-
-            if (foundMember != null)
+            if (member == null)
             {
                 _logger.Log($"Member with username: '{username}' not found.");
             }


### PR DESCRIPTION
## Summary
- replace stale `_users` and `_members` references with EF Core `DbContext` access
- fix member lookup logging logic
- initialize logger field earlier in `LogManagementForm`
- suppress nullable warning in `MainForm`

## Testing
- `dotnet build ComicRentalSystem_14Days.sln -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_6846ced478a48327900f869d9a328342