### PR TITLE
Fix: Use ToLower for case-insensitive username comparison in Authenti…

### DIFF
--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -43,7 +43,7 @@ namespace ComicRentalSystem_14Days.Services
         public User? GetUserByUsername(string username)
         {
             _logger.Log($"正在嘗試透過使用者名稱擷取使用者: {username}");
-            User? user = _context.Users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            User? user = _context.Users.FirstOrDefault(u => u.Username.ToLower() == username.ToLower());
           
             if (user == null)
             {
@@ -99,7 +99,7 @@ namespace ComicRentalSystem_14Days.Services
         public User? Login(string username, string password)
         {
             _logger.Log($"使用者名稱登入嘗試: {username}");
-            User? user = _context.Users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            User? user = _context.Users.FirstOrDefault(u => u.Username.ToLower() == username.ToLower());
 
             if (user == null)
             {
@@ -167,7 +167,7 @@ namespace ComicRentalSystem_14Days.Services
         public bool DeleteUser(string username)
         {
             _logger.Log($"正在嘗試刪除使用者: {username}"); 
-            User? userToDelete = _context.Users.FirstOrDefault(u => u.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            User? userToDelete = _context.Users.FirstOrDefault(u => u.Username.ToLower() == username.ToLower());
 
             if (userToDelete != null)
             {


### PR DESCRIPTION
…cationService

I replaced `ToUpperInvariant()` with `ToLower()` in LINQ queries within the `Login`, `GetUserByUsername`, and `DeleteUser` methods of `AuthenticationService.cs`.

This change addresses a `System.InvalidOperationException` that occurred because Entity Framework Core could not translate `string.ToUpperInvariant()` into a SQL query. Using `ToLower()` for both the database column value and the input username allows for case-insensitive comparisons that can be successfully translated to SQL.

This ensures that user lookups, login attempts, and deletions are performed case-insensitively with respect to the username, resolving the reported error and improving your experience.