### PR TITLE
Fix EF concurrency issue by scoping DbContext per call

### DIFF
--- a/ComicRentalSystem_14Days/Program.cs
+++ b/ComicRentalSystem_14Days/Program.cs
@@ -158,22 +158,22 @@ namespace ComicRentalSystem_14Days
             AppDbContext = new ComicRentalDbContext();
             AppLogger.Log("Main application DbContext initialized.");
 
-            if (AppDbContext != null && AppLogger != null)
+            if (AppLogger != null)
             {
-                AppComicService = new ComicService(AppDbContext, AppLogger);
-                AppLogger.Log("ComicService initialized with DbContext.");
+                AppComicService = new ComicService(AppLogger);
+                AppLogger.Log("ComicService initialized.");
 
-                AppMemberService = new MemberService(AppDbContext, AppLogger, AppComicService);
-                AppLogger.Log("MemberService initialized with DbContext.");
+                AppMemberService = new MemberService(AppLogger, AppComicService);
+                AppLogger.Log("MemberService initialized.");
 
-                AppAuthService = new AuthenticationService(AppDbContext, AppLogger);
-                AppLogger.Log("AuthenticationService initialized with DbContext.");
+                AppAuthService = new AuthenticationService(AppLogger);
+                AppLogger.Log("AuthenticationService initialized.");
 
                 AppAuthService.EnsureAdminUserExists("admin", "admin123");
             }
             else
             {
-                AppLogger?.LogError("Critical error: AppDbContext or AppLogger is null. Cannot initialize core services.");
+                AppLogger?.LogError("Critical error: AppLogger is null. Cannot initialize core services.");
             }
 
             Application.ThreadException += new System.Threading.ThreadExceptionEventHandler(Application_ThreadException);

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -10,20 +10,23 @@ namespace ComicRentalSystem_14Days.Services
 {
     public class MemberService
     {
-        private readonly ComicRentalDbContext _context;
         private readonly ILogger _logger;
         private readonly IComicService _comicService;
 
         public delegate void MemberDataChangedEventHandler(object? sender, EventArgs e);
         public event MemberDataChangedEventHandler? MembersChanged;
 
-        public MemberService(ComicRentalDbContext context, ILogger logger, IComicService comicService)
+        public MemberService(ILogger logger, IComicService comicService)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger), "MemberService logger cannot be null.");
             _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
 
-            _logger.Log("MemberService initialized with ComicRentalDbContext.");
+            _logger.Log("MemberService initialized.");
+        }
+
+        private ComicRentalDbContext CreateContext()
+        {
+            return new ComicRentalDbContext();
         }
 
         public async Task ReloadAsync()
@@ -42,13 +45,15 @@ namespace ComicRentalSystem_14Days.Services
         public List<Member> GetAllMembers()
         {
             _logger.Log("GetAllMembers called.");
-            return _context.Members.OrderBy(m => m.Name).ToList();
+            using var context = CreateContext();
+            return context.Members.OrderBy(m => m.Name).ToList();
         }
 
         public Member? GetMemberById(int id)
         {
             _logger.Log($"GetMemberById called for ID: {id}.");
-            var member = _context.Members.Find(id);
+            using var context = CreateContext();
+            var member = context.Members.Find(id);
             if (member == null)
             {
                 _logger.Log($"Member with ID: {id} not found.");
@@ -77,16 +82,17 @@ namespace ComicRentalSystem_14Days.Services
             }
 
             _logger.Log($"Attempting to add member: Name='{member.Name}'. ID will be DB-generated if {member.Id} is 0.");
-            if (_context.Members.Any(m => m.PhoneNumber == member.PhoneNumber))
+            using var context = CreateContext();
+            if (context.Members.Any(m => m.PhoneNumber == member.PhoneNumber))
             {
                 _logger.LogWarning($"AddMember: Member with phone number '{member.PhoneNumber}' already exists.");
                 // Original logic allowed adding, so we maintain that.
                 // For a stricter system, one might throw new InvalidOperationException($"Member with phone number '{member.PhoneNumber}' already exists.");
             }
-            _context.Members.Add(member);
+            context.Members.Add(member);
             try
             {
-                _context.SaveChanges();
+                context.SaveChanges();
                 _logger.Log($"Member '{member.Name}' (ID: {member.Id}) added to database.");
                 OnMembersChanged();
             }
@@ -107,7 +113,8 @@ namespace ComicRentalSystem_14Days.Services
             }
 
             _logger.Log($"Attempting to update member ID: {member.Id} (Name='{member.Name}').");
-            var existingMember = _context.Members.Find(member.Id);
+            using var context = CreateContext();
+            var existingMember = context.Members.Find(member.Id);
             if (existingMember == null)
             {
                 var ex = new InvalidOperationException($"Cannot update: Member with ID {member.Id} not found.");
@@ -115,16 +122,16 @@ namespace ComicRentalSystem_14Days.Services
                 throw ex;
             }
 
-            if (_context.Members.Any(m => m.PhoneNumber == member.PhoneNumber && m.Id != member.Id))
+            if (context.Members.Any(m => m.PhoneNumber == member.PhoneNumber && m.Id != member.Id))
             {
                  _logger.LogWarning($"UpdateMember: Another member with phone number '{member.PhoneNumber}' already exists.");
                 // Depending on business rules, might throw or just log.
             }
 
-            _context.Entry(existingMember).CurrentValues.SetValues(member);
+            context.Entry(existingMember).CurrentValues.SetValues(member);
             try
             {
-                _context.SaveChanges();
+                context.SaveChanges();
                 _logger.Log($"Member ID: {existingMember.Id} updated in database.");
                 OnMembersChanged();
             }
@@ -138,7 +145,8 @@ namespace ComicRentalSystem_14Days.Services
         public void DeleteMember(int id)
         {
             _logger.Log($"Attempting to delete member with ID: {id}.");
-            var memberToRemove = _context.Members.Find(id);
+            using var context = CreateContext();
+            var memberToRemove = context.Members.Find(id);
             if (memberToRemove == null)
             {
                 var ex = new InvalidOperationException($"Cannot delete: Member with ID {id} not found.");
@@ -153,10 +161,10 @@ namespace ComicRentalSystem_14Days.Services
                 throw new InvalidOperationException("Cannot delete member: Member has active comic rentals.");
             }
 
-            _context.Members.Remove(memberToRemove);
+            context.Members.Remove(memberToRemove);
             try
             {
-                _context.SaveChanges();
+                context.SaveChanges();
                 _logger.Log($"Member ID: {id} deleted from database.");
                 OnMembersChanged();
             }
@@ -175,7 +183,8 @@ namespace ComicRentalSystem_14Days.Services
                 return null;
             }
             _logger.Log($"已為姓名: '{name}' 呼叫 GetMemberByName。");
-            Member? member = _context.Members.FirstOrDefault(m => m.Name.ToUpperInvariant() == name.ToUpperInvariant());
+            using var context = CreateContext();
+            Member? member = context.Members.FirstOrDefault(m => m.Name.ToUpperInvariant() == name.ToUpperInvariant());
             if (member == null)
             {
                 _logger.Log($"Member with name: '{name}' not found.");
@@ -195,7 +204,8 @@ namespace ComicRentalSystem_14Days.Services
                 return null;
             }
             _logger.Log($"GetMemberByPhoneNumber called for phone: '{phoneNumber}'.");
-            var member = _context.Members.FirstOrDefault(m => m.PhoneNumber.Equals(phoneNumber));
+            using var context = CreateContext();
+            var member = context.Members.FirstOrDefault(m => m.PhoneNumber.Equals(phoneNumber));
             if (member == null)
             {
                 _logger.Log($"Member with phone: '{phoneNumber}' not found.");
@@ -215,7 +225,8 @@ namespace ComicRentalSystem_14Days.Services
                 return null;
             }
             _logger.Log($"GetMemberByUsername called for username: '{username}'.");
-            Member? member = _context.Members.FirstOrDefault(m => m.Username != null && m.Username.ToUpperInvariant() == username.ToUpperInvariant());
+            using var context = CreateContext();
+            Member? member = context.Members.FirstOrDefault(m => m.Username != null && m.Username.ToUpperInvariant() == username.ToUpperInvariant());
 
             if (member == null)
             {
@@ -234,11 +245,13 @@ namespace ComicRentalSystem_14Days.Services
             if (string.IsNullOrWhiteSpace(searchTerm))
             {
                 _logger.Log("SearchTerm is empty, returning all members ordered by Name.");
-                return _context.Members.OrderBy(m => m.Name).ToList();
+                using var contextAll = CreateContext();
+                return contextAll.Members.OrderBy(m => m.Name).ToList();
             }
 
             var lowerSearchTerm = searchTerm.ToLowerInvariant();
-            var results = _context.Members.Where(m =>
+            using var contextFiltered = CreateContext();
+            var results = contextFiltered.Members.Where(m =>
                 (m.Name != null && m.Name.ToLowerInvariant().Contains(lowerSearchTerm)) ||
                 (m.PhoneNumber != null && m.PhoneNumber.Contains(searchTerm)) || // Phone is exact search here
                 (m.Id.ToString().Equals(searchTerm)) ||


### PR DESCRIPTION
## Summary
- create a new `ComicRentalDbContext` inside service methods instead of sharing one instance
- update `Program` to use new service constructors
- adjust `MemberService`, `ComicService`, and `AuthenticationService` accordingly

## Testing
- `dotnet build ComicRentalSystem_14Days/ComicRentalSystem_14Days.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_6846da974708832788051e14d85cbae6