### PR TITLE
Switch comic cover paths to relative

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -1143,9 +1143,10 @@ namespace ComicRentalSystem_14Days
                 DataGridViewRow row = dgvAvailableComics.Rows[e.RowIndex];
                 if (row.DataBoundItem is Comic comic)
                 {
-                    if (!string.IsNullOrEmpty(comic.CoverImagePath) && File.Exists(comic.CoverImagePath))
+                    string fullPath = ComicEditForm.GetAbsoluteCoverImagePath(comic.CoverImagePath);
+                    if (!string.IsNullOrEmpty(fullPath) && File.Exists(fullPath))
                     {
-                        try { e.Value = Image.FromFile(comic.CoverImagePath); }
+                        try { e.Value = Image.FromFile(fullPath); }
                         catch { e.Value = _placeholderCoverImage; }
                     }
                     else


### PR DESCRIPTION
## Summary
- copy selected cover images to a `Covers` folder under the app directory
- store cover paths relative to the application root
- load cover images using the computed absolute path when needed

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511311d6d483279e5accea03a9fa50